### PR TITLE
Fix dependency issues

### DIFF
--- a/nostrpostrlib/build.gradle
+++ b/nostrpostrlib/build.gradle
@@ -9,11 +9,12 @@ dependencies {
     implementation 'com.madgag.spongycastle:core:1.51.0.0'
     implementation 'com.madgag.spongycastle:prov:1.51.0.0'
     implementation 'fr.acinq.secp256k1:secp256k1-kmp-jvm:0.6.4'
-    implementation 'fr.acinq.secp256k1:secp256k1-kmp-jni-jvm:0.6.4'
+    runtimeOnly 'fr.acinq.secp256k1:secp256k1-kmp-jni-jvm:0.6.4'
     implementation 'com.github.mgunlogson:cuckoofilter4j:1.0.1'
 
     testImplementation "org.junit.jupiter:junit-jupiter:5.8.2"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.8.2"
+    runtimeOnly 'fr.acinq.secp256k1:secp256k1-kmp-jni-jvm:0.6.4'
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.8.2"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.8.2"
 }


### PR DESCRIPTION
As the dependency configuration is presently, it leads to size of Android apps blowing up. This fixes that issue, while making sure that the code and test code work at runtime.